### PR TITLE
Changing RCTBridge import to React namespace per RN 0.40 update

### DIFF
--- a/RNMotionManager/Accelerometer.m
+++ b/RNMotionManager/Accelerometer.m
@@ -4,7 +4,7 @@
 //  Created by Patrick Williams in beautiful Seattle, WA.
 //
 
-#import "RCTBridge.h"
+#import <React/RCTBridge.h>
 #import "RCTEventDispatcher.h"
 #import "Accelerometer.h"
 

--- a/RNMotionManager/Gyroscope.m
+++ b/RNMotionManager/Gyroscope.m
@@ -4,7 +4,7 @@
 //  Created by Patrick Williams in beautiful Seattle, WA.
 //
 
-#import "RCTBridge.h"
+#import <React/RCTBridge.h>
 #import "RCTEventDispatcher.h"
 #import "Gyroscope.h"
 

--- a/RNMotionManager/Magnetometer.m
+++ b/RNMotionManager/Magnetometer.m
@@ -4,7 +4,7 @@
 //  Created by Patrick Williams in beautiful Seattle, WA.
 //
 
-#import "RCTBridge.h"
+#import <React/RCTBridge.h>
 #import "RCTEventDispatcher.h"
 #import "Magnetometer.h"
 


### PR DESCRIPTION
In React Native 0.40 everyone is getting duplicate class errors, this fixes those 👍 