### PR TITLE
Changing RCTBridge import to React namespace per RN 0.40 update

### DIFF
--- a/RNMotionManager/Accelerometer.h
+++ b/RNMotionManager/Accelerometer.h
@@ -4,7 +4,7 @@
 //  Created by Patrick Williams in beautiful Seattle, WA.
 //
 
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 #import <CoreMotion/CoreMotion.h>
 
 @interface Accelerometer : NSObject <RCTBridgeModule> {

--- a/RNMotionManager/Accelerometer.m
+++ b/RNMotionManager/Accelerometer.m
@@ -4,7 +4,7 @@
 //  Created by Patrick Williams in beautiful Seattle, WA.
 //
 
-#import "RCTBridge.h"
+#import <React/RCTBridge.h>
 #import "RCTEventDispatcher.h"
 #import "Accelerometer.h"
 

--- a/RNMotionManager/Accelerometer.m
+++ b/RNMotionManager/Accelerometer.m
@@ -5,7 +5,7 @@
 //
 
 #import <React/RCTBridge.h>
-#import "RCTEventDispatcher.h"
+#import <React/RCTEventDispatcher.h>
 #import "Accelerometer.h"
 
 @implementation Accelerometer

--- a/RNMotionManager/Gyroscope.h
+++ b/RNMotionManager/Gyroscope.h
@@ -4,7 +4,7 @@
 //  Created by Patrick Williams in beautiful Seattle, WA.
 //
 
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 #import <CoreMotion/CoreMotion.h>
 
 @interface Gyroscope : NSObject <RCTBridgeModule> {

--- a/RNMotionManager/Gyroscope.m
+++ b/RNMotionManager/Gyroscope.m
@@ -4,7 +4,7 @@
 //  Created by Patrick Williams in beautiful Seattle, WA.
 //
 
-#import "RCTBridge.h"
+#import <React/RCTBridge.h>
 #import "RCTEventDispatcher.h"
 #import "Gyroscope.h"
 

--- a/RNMotionManager/Gyroscope.m
+++ b/RNMotionManager/Gyroscope.m
@@ -5,7 +5,7 @@
 //
 
 #import <React/RCTBridge.h>
-#import "RCTEventDispatcher.h"
+#import <React/RCTEventDispatcher.h>
 #import "Gyroscope.h"
 
 @implementation Gyroscope

--- a/RNMotionManager/Magnetometer.h
+++ b/RNMotionManager/Magnetometer.h
@@ -4,7 +4,7 @@
 //  Created by Patrick Williams in beautiful Seattle, WA.
 //
 
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 #import <CoreMotion/CoreMotion.h>
 
 @interface Magnetometer : NSObject <RCTBridgeModule> {

--- a/RNMotionManager/Magnetometer.m
+++ b/RNMotionManager/Magnetometer.m
@@ -4,7 +4,7 @@
 //  Created by Patrick Williams in beautiful Seattle, WA.
 //
 
-#import "RCTBridge.h"
+#import <React/RCTBridge.h>
 #import "RCTEventDispatcher.h"
 #import "Magnetometer.h"
 

--- a/RNMotionManager/Magnetometer.m
+++ b/RNMotionManager/Magnetometer.m
@@ -5,7 +5,7 @@
 //
 
 #import <React/RCTBridge.h>
-#import "RCTEventDispatcher.h"
+#import <React/RCTEventDispatcher.h>
 #import "Magnetometer.h"
 
 @implementation Magnetometer


### PR DESCRIPTION
In React Native 0.40 everyone is getting duplicate class errors, this fixes those 👍